### PR TITLE
Fixed spelling errors; malformed example cV

### DIFF
--- a/cV - 2.1.md
+++ b/cV - 2.1.md
@@ -41,7 +41,7 @@ Less formally, the cV has the form **_{Base}.{Vector}_** where **_{Base}_** is a
 
 **Note**: The following characters are reserved for the specification { ‘.’, ‘!’ }
 
-**Note**: The encoded **_{Base}_** consists of 22 base64 characters and, if left unrestriced, technically allows for 132-bit values. In order to support interop with tracing standards that use UUID's, the **_{Base}_** value is restricted to 128-bits assuring reliable conversion to/from the UUID format. This is the reason the last element of the **_{Base}_** is restricted to a subset of allowable base64 characters.
+**Note**: The encoded **_{Base}_** consists of 22 base64 characters and, if left unrestricted, technically allows for 132-bit values. In order to support interoperability with tracing standards that use UUIDs, the **_{Base}_** value is restricted to 128-bits assuring reliable conversion to/from the UUID format. This is the reason the last element of the **_{Base}_** is restricted to a subset of allowable base64 characters.
 
 ### Examples
 
@@ -127,8 +127,8 @@ The Spin operator mitigates this, by inserting an element with entropy so that r
 
 All operator implementations will include a check if the output exceeds 127 bytes in length. If it does, all operators will return the input vector appended with a '!' character. 
 
-The presence of the trailing '!' character indicates that a previous attempt to mutate the vector failed and the vector should therefore be considered immutable. So any operator that recieves an input vector with a trailing '!' character simply returns the same value. 
+The presence of the trailing '!' character indicates that a previous attempt to mutate the vector failed and the vector should therefore be considered immutable. So any operator that receives an input vector with a trailing '!' character simply returns the same value. 
 
-**Note**: The recommeded approach when encountering terminated vectors would be to seed a new correlation vector and associate the terminated vector with the new one using additional telemetry metadata.
+**Note**: The recommended approach when encountering terminated vectors would be to seed a new correlation vector and associate the terminated vector with the new one using additional telemetry metadata.
 
 

--- a/cV - 3.0.md
+++ b/cV - 3.0.md
@@ -12,7 +12,7 @@ This document covers:
 
 Here are the key **additional** design goals:
 
-1. Support interop with W3C Distributed Tracing [Link](https://github.com/w3c/distributed-tracing)
+1. Support interoperability with W3C Distributed Tracing [Link](https://github.com/w3c/distributed-tracing)
 2. Support for vector reset semantics to support traces of arbitrary depth
 3. Support for versioning
 
@@ -20,13 +20,13 @@ Here are the key **additional** design goals:
 
 Represented by the following simply grammar ABNF specification
 
-1. vector = base ver delim suffix
-2. base = 21char lastChar
-3. ver = "A"
+1. vector = ver delim base suffix
+2. ver = "A"
+3. base = 21char lastChar
 4. char = %x30-39 / %x41-5A / %61-7A / %x2F / %2B ; base64 characters
 5. lastChar = "A" / "Q" / "g" / "w" ; base64 characters with four least significant bits of zero
 6. suffix = init / init vector
-7. init = tick / sharp id delim tick / dash id delim tick
+7. init = delim tick / sharp id delim tick / dash id delim tick
 8. vector = term / term vector
 9. term = delim tick / under id delim tick
 10. tick = 1*8(%x30-39 / %x41-46) ; hex encoded counter
@@ -40,26 +40,26 @@ Represented by the following simply grammar ABNF specification
 
 **Note**: The following characters are reserved for the specification { ‘.’, ‘-’, ‘_’, ‘#’, ‘!’ }
 
-**Note**: The encoded **_{Base}_** consists of 22 base64 characters and, if left unrestriced, technically allows for 132-bit values. In order to support interop with tracing standards that use UUID's, the **_{Base}_** value is restricted to 128-bits assuring reliable conversion to/from the UUID format. This is the reason the last element of the **_{Base}_** is restricted to a subset of allowable base64 characters.
+**Note**: The encoded **_{Base}_** consists of 22 base64 characters and, if left unrestricted, technically allows for 132-bit values. In order to support interoperability with tracing standards that use UUIDs, the **_{Base}_** value is restricted to 128-bits assuring reliable conversion to/from the UUID format. This is the reason the last element of the **_{Base}_** is restricted to a subset of allowable base64 characters.
 
-**Note**: Base64 is case sensitive. So in the cV base, 'a' is distinct from 'A'. Counters and Ids are encoded in hexadecimal where there is no such distinction. However, this indifference does not allow us to apply a lexical sort. So by convention and for a more accessible sort, we restrict the use of only **upper case** characters for the hexadecimal encoding when used for ids or counters.
+**Note**: Base64 is case sensitive. Since the cV base is base64 encoded, 'a' is distinct from 'A' in the base. Counters and IDs are encoded in hexadecimal where there is no such distinction. However, this indifference does not allow us to apply a lexical sort. So by convention and for a more accessible sort, the hexadecimal encoding is restricted to only **upper case** characters, when used for ids or counters.
 
 ### Examples
 
-1. PmvzQKgYek6Sdk/T5sWaqwA.0 // Base: PmvzQKgYek6Sdk/T5sWaqwA
-2. PmvzQKgYek6Sdk/T5sWaqwA.B
-3. e8iECJiOvUGPvOVtchxG9g1A.F.A.23 // All elements in the vector are logical ticks that resulted from an Increment operation
-4. e8iECJiOvUGPvOVtchxG9gA-304773F68A307E98.1.F.A.234 // 304773F68A307E98 is a Span Id from the incoming W3C TraceParent header
-5. e8iECJiOvUGPvOVtchxG9gA.1.F.A.23_93816B91E430A7BB.1 // 93816B91E430A7BB was generated during a Spin operation
-6. e8iECJiOvUGPvOVtchxG9g1A#B6A5FFD77977E2AE.0 // B6A5FFD77977E2AE was generated during a Reset operation
+1. A.PmvzQKgYek6Sdk/T5sWaqw.0 // Base: PmvzQKgYek6Sdk/T5sWaqw; Version: A
+2. A.PmvzQKgYek6Sdk/T5sWaqw.B
+3. A.e8iECJiOvUGPvOVtchxG9g1.F.A.23 // All elements in the vector are logical ticks that resulted from an Increment operation
+4. A.e8iECJiOvUGPvOVtchxG9g-304773F68A307E98.1.F.A.234 // 304773F68A307E98 is a Span ID from the incoming W3C TraceParent header
+5. A.e8iECJiOvUGPvOVtchxG9g.1.F.A.23_93816B91E430A7BB.1 // 93816B91E430A7BB was generated during a Spin operation
+6. A.e8iECJiOvUGPvOVtchxG9g1#B6A5FFD77977E2AE.0 // B6A5FFD77977E2AE was generated during a Reset operation
 
 ## Operators
 
 To help define the vector operators are the following definitions and notations:
 
-- X is a valid base, i.e. 23 base64 encoded characters (terminating with 'A' indicative of version)
-- S is the correlation vector suffix, i.e. the suffix section excluding the base. XS would denote a valid correlation vector.
-- V is a valid correlation vector
+- X is a valid base, i.e. 22 base64 encoded characters
+- S is the correlation vector suffix, i.e. the suffix section excluding the base. A.**XS** would denote a valid cV 3.0.
+- V is a valid correlation vector.
 - N is a valid 4-byte unsigned integer
 - M is an 8-byte unsigned integer designed to offer a combination of sort and entropy and constructed as follows:
   - M is composed of two 4-byte sections referred to as AB where A is the most significant section that is derived from UTC time as follows:
@@ -74,13 +74,13 @@ The use case for M is described in the Spin operator section.
 
 ### Seed
 
-**Definition**: {} => X.0
+**Definition**: {} => A.**X**.0
 
 Invoked when initializing the vector.
 
 ### Increment
 
-**Definition**: V.N => V.(N+1)
+**Definition**: **V**.N => **V**.(N+1)
 
 The Increment operator may be invoked arbitrarily to denote a logical tick. But it must be invoked prior to the creation of a new outgoing control flow to generate a unique vector value suitable for transmission such as, on an outgoing HTTP/RPC call.
 
@@ -90,25 +90,25 @@ If an increment is not possible, the workaround is to have the component that re
 
 ### Increment Examples
 
-1. PmvzQKgYek6Sdk/T5sWaqwA.9 => PmvzQKgYek6Sdk/T5sWaqwA.A
-2. PmvzQKgYek6Sdk/T5sWaqwA.1.F.A.23 => PmvzQKgYek6Sdk/T5sWaqwA.1.F.A.24
-3. PmvzQKgYek6Sdk/T5sWaqwA-304773F68A307E98.4 => PmvzQKgYek6Sdk/T5sWaqwA-304773F68A307E98.5
-4. PmvzQKgYek6Sdk/T5sWaqwA.1.F.A.23_B6A5E62FC38E9974.1 => PmvzQKgYek6Sdk/T5sWaqwA.1.F.A.23_B6A5E62FC38E9974.2
-5. PmvzQKgYek6Sdk/T5sWaqwA#B6A5FFD77977E2AE.0 => PmvzQKgYek6Sdk/T5sWaqwA#B6A5FFD77977E2AE.1
+1. A.PmvzQKgYek6Sdk/T5sWaqw.9 => A.PmvzQKgYek6Sdk/T5sWaqw.A
+2. A.PmvzQKgYek6Sdk/T5sWaqw.1.F.A.23 => A.PmvzQKgYek6Sdk/T5sWaqw.1.F.A.24
+3. A.PmvzQKgYek6Sdk/T5sWaqw-304773F68A307E98.4 => A.PmvzQKgYek6Sdk/T5sWaqw-304773F68A307E98.5
+4. A.PmvzQKgYek6Sdk/T5sWaqw.1.F.A.23_B6A5E62FC38E9974.1 => A.PmvzQKgYek6Sdk/T5sWaqw.1.F.A.23_B6A5E62FC38E9974.2
+5. A.PmvzQKgYek6Sdk/T5sWaqw#B6A5FFD77977E2AE.0 => A.PmvzQKgYek6Sdk/T5sWaqw#B6A5FFD77977E2AE.1
 
 ### Extend
 
 The Extend operator is to be used once on an incoming control flow, to extend the vector to create a vector element for the receiving span, such as on an incoming HTTP/RPC call.
 
-**Definition**: V => V.0
+**Definition**: **V** => **V**.0
 
 ### Extend Examples
 
-1. PmvzQKgYek6Sdk/T5sWaqwA.9 => PmvzQKgYek6Sdk/T5sWaqwA.9.0
-2. PmvzQKgYek6Sdk/T5sWaqwA.1.F.A.23 => PmvzQKgYek6Sdk/T5sWaqwA.1.F.A.23.0
-3. PmvzQKgYek6Sdk/T5sWaqwA-304773F68A307E98.4 => PmvzQKgYek6Sdk/T5sWaqwA-304773F68A307E98.4.0
-4. PmvzQKgYek6Sdk/T5sWaqwA.1.F.A.23_B6A5E62FC38E9974.1 => PmvzQKgYek6Sdk/T5sWaqwA.1.F.A.23_B6A5E62FC38E9974.1.0
-5. PmvzQKgYek6Sdk/T5sWaqwA#B6A5FFD77977E2AE.1 => PmvzQKgYek6Sdk/T5sWaqwA#B6A5FFD77977E2AE.1.0
+1. A.PmvzQKgYek6Sdk/T5sWaqw.9 => A.PmvzQKgYek6Sdk/T5sWaqw.9.0
+2. A.PmvzQKgYek6Sdk/T5sWaqw.1.F.A.23 => A.PmvzQKgYek6Sdk/T5sWaqw.1.F.A.23.0
+3. A.PmvzQKgYek6Sdk/T5sWaqw-304773F68A307E98.4 => A.PmvzQKgYek6Sdk/T5sWaqw-304773F68A307E98.4.0
+4. A.PmvzQKgYek6Sdk/T5sWaqw.1.F.A.23_B6A5E62FC38E9974.1 => A.PmvzQKgYek6Sdk/T5sWaqw.1.F.A.23_B6A5E62FC38E9974.1.0
+5. A.PmvzQKgYek6Sdk/T5sWaqw#B6A5FFD77977E2AE.1 => A.PmvzQKgYek6Sdk/T5sWaqw#B6A5FFD77977E2AE.1.0
 
 ### Spin
 
@@ -125,23 +125,23 @@ In such instances, without a uniquely incremented value on each incoming flow, t
 
 The Spin operator mitigates this, by inserting an element with entropy so that repeated invocations result in unique values. However purely using entropy erodes the utility of the vector when it is used to provide a sort during data processing. For this reason, the construction precedes this with an element derived from UTC time. This supports the sort property of the vector while reducing the chances of collision.
 
-**Definition**: V => V_M.0
+**Definition**: **V** => **V**_**M**.0
 
 ### Spin Examples
 
-1. PmvzQKgYek6Sdk/T5sWaqwA.9 => PmvzQKgYek6Sdk/T5sWaqwA.9_B6A6A13E588CF82F.0
-2. PmvzQKgYek6Sdk/T5sWaqwA.1.F.A.23 => PmvzQKgYek6Sdk/T5sWaqwA.1.F.A.23_B6A6A13E588CF82F.0
-3. PmvzQKgYek6Sdk/T5sWaqwA-304773F68A307E98.4 => PmvzQKgYek6Sdk/T5sWaqwA-304773F68A307E98.4_B6A6A13E588CF82F.0
-4. PmvzQKgYek6Sdk/T5sWaqwA.1.F.A.23_B6A5E62FC38E9974.1 => PmvzQKgYek6Sdk/T5sWaqwA.1.F.A.23_B6A5E62FC38E9974.1_B6A6A13E588CF82F.0
-5. PmvzQKgYek6Sdk/T5sWaqwA#B6A5FFD77977E2AE.1 => PmvzQKgYek6Sdk/T5sWaqwA#B6A5FFD77977E2AE.1_B6A6A13E588CF82F.0
+1. A.PmvzQKgYek6Sdk/T5sWaqw.9 => A.PmvzQKgYek6Sdk/T5sWaqw.9_B6A6A13E588CF82F.0
+2. A.PmvzQKgYek6Sdk/T5sWaqw.1.F.A.23 => A.PmvzQKgYek6Sdk/T5sWaqw.1.F.A.23_B6A6A13E588CF82F.0
+3. A.PmvzQKgYek6Sdk/T5sWaqw-304773F68A307E98.4 => A.PmvzQKgYek6Sdk/T5sWaqw-304773F68A307E98.4_B6A6A13E588CF82F.0
+4. A.PmvzQKgYek6Sdk/T5sWaqw.1.F.A.23_B6A5E62FC38E9974.1 => A.PmvzQKgYek6Sdk/T5sWaqw.1.F.A.23_B6A5E62FC38E9974.1_B6A6A13E588CF82F.0
+5. A.PmvzQKgYek6Sdk/T5sWaqw#B6A5FFD77977E2AE.1 => A.PmvzQKgYek6Sdk/T5sWaqw#B6A5FFD77977E2AE.1_B6A6A13E588CF82F.0
 
 ### Reset
 
 The Reset operator is meant to be invoked implicitly, whenever an operation can potentially result in the total vector length exceeding its maximum length. The mutation is specific to the operation that is being attempted, with the basic goal of truncating the vector.
 
-- Increment: XS.N => X#M.(N+1)
-- Extend: XS => X#M.0
-- Spin: XS => X#M.0
+- Increment: A.**XS**.N => A.**X**#**M**.(N+1)
+- Extend: A.**XS** => A.**X**#**M**.0
+- Spin: A.**XS** => A.**X**#**M**.0
 
 Note: When Reset is invoked in the context of the Spin operator, the operations are identical to those of Extend. The reason for this is that the Reset operator already introduces a sort-entropy element (by introducing M) that makes the vector value unique to the span, thereby making the addition of another such element moot.
 
@@ -151,17 +151,17 @@ In all cases, the Reset Operation records S, i.e. the value associated with the 
 
 Let:
 
-- X = PmvzQKgYek6Sdk/T5sWaqwA
-- S = .1.FA.A1.23_B6A5E62FC38E9974.1_B6A6A13E588CF82F.2A.AB.213_B6A92D24A00C0F9B.47.8B.12.34.A123.2B.23.41.AB
+- **X** = PmvzQKgYek6Sdk/T5sWaqw
+- **S** = .1.FA.A1.23_B6A5E62FC38E9974.1_B6A6A13E588CF82F.2A.AB.213_B6A92D24A00C0F9B.47.8B.12.34.A123.2B.23.41.AB
 
 XS is 126 bytes (assuming ASCII encoding and 1 byte per character).
 
-- Increment: XS.F => X#B6B3AB078D8000FA.10
-  - Recorded mapping: S <=> B6B3AB078D8000FA
-- Extend: XS => X#B6B3AB078D8000FA.0
-  - Recorded mapping: S <=> B6B3AB078D8000FA
-- Spin: XS => X#B6B3AB078D8000FA.0
-  - Recorded mapping: S <=> B6B3AB078D8000FA
+- Increment: A.**XS**.F => A.**X**#B6B3AB078D8000FA.10
+  - Recorded mapping: **S** <=> B6B3AB078D8000FA
+- Extend: A.**XS** => A.**X**#B6B3AB078D8000FA.0
+  - Recorded mapping: **S** <=> B6B3AB078D8000FA
+- Spin: A.**XS** => A.**X**#B6B3AB078D8000FA.0
+  - Recorded mapping: **S** <=> B6B3AB078D8000FA
 
 Note that the properties of M as defined above allows for sorting events across the trace reset boundary, even in the absence of intermediate spans that contain the previous value of the vector. This is based on the time component that is the most significant 4 bytes in M.
 
@@ -169,100 +169,112 @@ Note that the properties of M as defined above allows for sorting events across 
 
 Summarizing the key differences from v2.1:
 
-1. The base is appended with a single base64 character for version and reserved for future use. For 3.0, this is simply 'A' (base64 0).
+1. The base is preceded with a single base64 character for version and reserved for future use. For 3.0, this is simply 'A' (base64 0).
 2. The vector element counters are encoded in Hex unlike the decimal encoding in v2.1. They continue to be 4 byte unsigned counters.
-3. Support for **optional** prefix sections on each stage, where each section starts with a reserved character and followed by an 8 byte identifier that is hex encoded (16 hex characters). This is done for Spin (prefixed by '_'), Reset (prefixed by '#') and W3C interop (prefixed by '-'). The W3C interop is described in a section below.
-4. With the Reset operator, the cV 3.0 format can support causality chains of indefnite depth. It is automatically invoked when other operations can exceed the maximum length. This arrangement means that the updated format does not rely on the '!' character in v2.1 to indicate further immutability. 
+3. Support for two **optional** vector prefix segments that use a reserved character followed by an 8 byte hex encoded identifier to support
 
-## Interop with cV 2.1
+   - Reset (prefixed by '#')
+   - W3C interop (prefixed by '-')
+
+4. Support for **optional** prefix sections on each vector element to support Spin (prefixed by '_') followed by a 8 byte hex encoded identifier.
+5. With the Reset operator, the cV 3.0 format can support causality chains of indefinite depth. It is automatically invoked when other operations can exceed the maximum length. This arrangement means that the updated format does not rely on the '!' character in v2.1 to indicate further immutability.
+
+## Interoperability with cV 2.1
 
 The typical use case is when a system using cV v3.0 receives a call from a component that uses v2.1.
 
 For the incoming v2.1 cV of the form X.V, where:
 
-- X is a compliant 22 base64 encoded base
-- V is the '.' delimited vector
+- **X** is a compliant 22 base64 encoded base
+- **V** is the '.' delimited vector
 
-The equivalent v3.0 cV has the form: XA.V
+The equivalent v3.0 cV has the form: A.**X**.**V**
 
-**Note**: While it is possible to convert a cV 3.0 to cV 2.1, it is **not** recommeded for a system using cV 3.0 to propagate to a system with cV 2.1. This is primarily on account of the more compact encoding on the v3.0 format which can generate equivalent cV 2.1 values that exceed maximum length. 
+**Note**: While it is possible to convert a cV 3.0 to cV 2.1, it is **not** recommended for a system using cV 3.0 to propagate to a system with cV 2.1. This is primarily on account of the more compact hex encoding on the v3.0 format which can generate equivalent cV 2.1 (that uses decimal) values that exceed maximum length.
 
 ### cV 2.1 to cV 3.0 conversion examples
 
-1. PmvzQKgYek6Sdk/T5sWaqw.0 => PmvzQKgYek6Sdk/T5sWaqwA.0
-2. e8iECJiOvUGPvOVtchxG9g.1.23 => e8iECJiOvUGPvOVtchxG9gA.1.23
+1. PmvzQKgYek6Sdk/T5sWaqw.0 => A.PmvzQKgYek6Sdk/T5sWaqw.0
+2. e8iECJiOvUGPvOVtchxG9g.1.23 => A.e8iECJiOvUGPvOVtchxG9g.1.23
 
 ### cV 2.1 with trailing '!'
 
 The presence of the trailing '!' character indicates that the incoming vector is immutable as per the 2.1 specification. The recommended approach when dealing with such a cV in the 2.1 specification would be to create a new cV (with a new base using the Seed operator) and emit the association between the new and old cVs for trace reconstruction.
 
-To convert such a v2.1 cV to v3.0, invoke the Reset operator.
+To convert such a v2.1 cV to v3.0, invoke the Reset operator after adding the version prefix.
 
 ### Immutable cV 2.1 to cV 3.0 conversion example
 
-CgOLQOn9Gkmd4pM720ciZA.1.15.3226329855.4111101367.10.23.8.3226332926.1671828776.2345.12.3.243.544.3226336576.3422508575.23.1.34! =>
-CgOLQOn9Gkmd4pM720ciZAA#B6B3AB078D8000FA.0
+**cV 2.1**: CgOLQOn9Gkmd4pM720ciZA.1.15.3226329855.4111101367.10.23.8.3226332926.1671828776.2345.12.3.243.544.3226336576.3422508575.23.1.34!
+
+=>
+
+**cV 3.0**: A.CgOLQOn9Gkmd4pM720ciZA#B6B3AB078D8000FA.0
 
 - Recorded mapping: .1.15.3226329855.4111101367.10.23.8.3226332926.1671828776.2345.12.3.243.544.3226336576.3422508575.23.1.34! <=> B6B3AB078D8000FA
 
-## Interop with W3C
+## Interoperability with W3C
 
 The primary [W3C](https://github.com/w3c/distributed-tracing) header that communicates the position of the incoming request in a trace is **traceparent**, which has the following format:
 
-version-format "-" **trace-id** "-" **parent-id** "-" trace-flags
+**version-format** "-" **trace-id** "-" **parent-id** "-" **trace-flags**
 
-For the purposes of interop, we are primarily concerned with mapping **trace_id** and **parent-id** to their respective analogs in the cV format.
+For the purposes of interoperability, we are primarily concerned with mapping **trace_id** and **parent-id** to their respective analogs in the cV format.
 
 Semantically,
 
-- **trace_id** maps to the cV base. They have identical entropy (atleast in the current versions).
-- **parent-id** maps to the incoming vector
+- **trace_id** maps to the cV base. They have identical entropy (at least in the current versions).
+- **parent-id** maps to the incoming parent vector, i.e. the vector without its most recent extension.
 
 ### TraceParent to cV 3.0
 
-The typical use case is when a cV instrumented system receives an incoming call with traceparent header. 
+The typical use case is when a cV instrumented system receives an incoming call with traceparent header.
 
-Generating a cV from an incoming traceparent value, has the following contruction steps: 
+Generating a cV from an incoming traceparent value, has the following construction steps:
 
-- Encode the trace_id into base64
-- Append with the cV 3.0 version 'A'
-- Append the '-' character denoting the W3C interop
+- Append with the cV 3.0 version 'A.'.
+- Encode the trace_id into base64 and append it.
+- Append the '-' character denoting the W3C interoperability.
 - Convert the parent_id to upper case, and append it.
-- Append a new vector counter initialized to zero, with the '.' delimiter 
+- Append a new vector counter initialized to zero, with the '.' delimiter.
 
-The generated cV will have the following form: [*encode_base64(trace_id)*]A#[*uppercase(parent_id)*].0
+The generated cV will have the following form: A.[**encode_base64(trace_id)**]#[**uppercase(parent_id)**].0
 
 ### W3C to cV 3.0 conversion example
 
-traceparent: 00-0af7651916cd43dd8448eb211c80319c-b9c7c989f97918e1-01
-=>
-cV 3.0: CvdlGRbNQ92ESOshHIAxnAA-B9C7C989F97918E1.0
+**traceparent**: 00-0af7651916cd43dd8448eb211c80319c-b9c7c989f97918e1-01
+
+=> 
+
+**cV 3.0**: A.CvdlGRbNQ92ESOshHIAxnA-B9C7C989F97918E1.0
 
 ### cV 3.0 to TraceParent
 
 The typical use case is when a cV instrumented system is making a call out to component that only understands the W3C headers.
 
-The cV encodes more information in the vector than that encoded in the parent_Id in traceparent. For this reason, when converting to cV 3.0, we generate a new span Id and associcate this with the span.
+The cV encodes more information in the vector than that encoded in the parent_id in traceparent. For this reason, when converting to cV 3.0, we generate a new span ID and associate this with the span.
 
-Generating a traceparent from an existing cV 3.0 value, has the following contruction steps: 
+Generating a traceparent from an existing cV 3.0 value, has the following construction steps:
 
 - Start with a prefix for the appropriate version format. This is currently "00-".
 - Encode the cV base (without the version character) into lower case hexadecimal.
 - Append a "-" character.
-- Generate a new span Id (random generation, 8 byte, lower case hexadecimal encoded) 
-  - Emit the association between the vector segement and the newly created span Id for trace reconstruction.
-- Append the span Id.
+- Generate a new span ID (random generation, 8 byte, lower case hexadecimal encoded)
+  - Emit the association between the vector segment and the newly created span ID for trace reconstruction.
+- Append the span ID.
 - Append a "-" character
 - Append suitable trace-flags as defined in the W3C specification. Default would be "00".
 
-The generated traceparent will have the following form: 00-[*lowercase(encode_hex(cVBase))*]-[*lowercase(random_span_id)*]-[*trace-flags*]
+The generated traceparent will have the following form: 00-[**lowercase(encode_hex(cVBase))**]-[**lowercase(random_span_id)**]-[*trace-flags*]
 
 Note that the cV should have been incremented prior to the traceparent generation for outgoing spans.
 
 ### cV 3.0 to W3C conversion example
 
-cV 3.0: PmvzQKgYek6Sdk/T5sWaqwA.1.F.A.23_B6A5E62FC38E9974.2
+**cV 3.0**: A.PmvzQKgYek6Sdk/T5sWaqw.1.F.A.23_B6A5E62FC38E9974.2
+
 =>
-traceparent: 00-3e6bf340a8187a4e92764fd3e6C59aab-10f076ab0ba9d1c9-00
+
+**traceparent**: 00-3e6bf340a8187a4e92764fd3e6C59aab-10f076ab0ba9d1c9-00
 
 - Recorded mapping: .1.F.A.23_B6A5E62FC38E9974.2 <=> 10f076ab0ba9d1c9

--- a/cV - 3.0.md
+++ b/cV - 3.0.md
@@ -48,10 +48,10 @@ Represented by the following simply grammar ABNF specification
 
 1. A.PmvzQKgYek6Sdk/T5sWaqw.0 // Base: PmvzQKgYek6Sdk/T5sWaqw; Version: A
 2. A.PmvzQKgYek6Sdk/T5sWaqw.B
-3. A.e8iECJiOvUGPvOVtchxG9g1.F.A.23 // All elements in the vector are logical ticks that resulted from an Increment operation
+3. A.e8iECJiOvUGPvOVtchxG9g.F.A.23 // All elements in the vector are logical ticks that resulted from an Increment operation
 4. A.e8iECJiOvUGPvOVtchxG9g-304773F68A307E98.1.F.A.234 // 304773F68A307E98 is a Span ID from the incoming W3C TraceParent header
 5. A.e8iECJiOvUGPvOVtchxG9g.1.F.A.23_93816B91E430A7BB.1 // 93816B91E430A7BB was generated during a Spin operation
-6. A.e8iECJiOvUGPvOVtchxG9g1#B6A5FFD77977E2AE.0 // B6A5FFD77977E2AE was generated during a Reset operation
+6. A.e8iECJiOvUGPvOVtchxG9g#B6A5FFD77977E2AE.0 // B6A5FFD77977E2AE was generated during a Reset operation
 
 ## Operators
 
@@ -174,7 +174,7 @@ Summarizing the key differences from v2.1:
 3. Support for two **optional** vector prefix segments that use a reserved character followed by an 8 byte hex encoded identifier to support
 
    - Reset (prefixed by '#')
-   - W3C interop (prefixed by '-')
+   - W3C interoperability (prefixed by '-')
 
 4. Support for **optional** prefix sections on each vector element to support Spin (prefixed by '_') followed by a 8 byte hex encoded identifier.
 5. With the Reset operator, the cV 3.0 format can support causality chains of indefinite depth. It is automatically invoked when other operations can exceed the maximum length. This arrangement means that the updated format does not rely on the '!' character in v2.1 to indicate further immutability.


### PR DESCRIPTION
Fixed spelling errors and 23-character cV examples in cV base.